### PR TITLE
docs: fix and expand CI/deployment variable documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,6 @@ jobs:
     uses: ./.github/workflows/code-quality.yaml
 
   deploy:
-    uses: Rutger505-Org/kubernetes-infrastructure/.github/workflows/deployments.yaml@990a3d3
+    uses: Rutger505-Org/kubernetes-infrastructure/.github/workflows/deployments.yaml@main
     secrets: inherit
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,6 @@ jobs:
     uses: ./.github/workflows/code-quality.yaml
 
   deploy:
-    uses: Rutger505-Org/kubernetes-infrastructure/.github/workflows/deployments.yaml@main
+    uses: Rutger505-Org/kubernetes-infrastructure/.github/workflows/deployments.yaml@990a3d3
     secrets: inherit
 

--- a/README.md
+++ b/README.md
@@ -28,26 +28,28 @@ bun dev
 
 #### Variables
 
-- `APPLICATION_NAME` - Used as an identifier for multiple actions such as the terraform workspace.
-- `IMAGE_REPOSITORY` - Image repository to store image to.
-- `BASE_DOMAIN` - Domain where to host the application (tags deployed to this domain, pull request's to a subdomain: the sha of the commit.)
-- `DOCKERHUB_USERNAME` - Dockerhub username
-- `AUTH_EMAIL_FROM_NAME` - Name and Email address of magic link sender (e.g. `Next Template <example@email.com>`)
+- `APPLICATION_NAME` - Used as an identifier for multiple actions such as the Kubernetes deployment name and Terraform workspace.
+- `IMAGE_REPOSITORY` - Docker image repository to push the built image to (e.g. `dockerhub-username/app-name`).
+- `BASE_DOMAIN` - Domain where to host the application. Tags are deployed to this domain; pull requests to a subdomain using the commit SHA (e.g. `<sha>.yourdomain.com`).
 
 #### Secrets
 
-- `AUTH_SECRET` - AUTH secret for encrypting jwt's
-- `AUTH_EMAIL_USER` - SMTP username (for gmail, this is your email address)
-- `AUTH_EMAIL_HOST` - SMTP host (e.g. `smtp.gmail.com`)
-- `AUTH_EMAIL_PORT` - SMTP port (e.g. `465`)
-- `AUTH_EMAIL_PASSWORD` - SMTP password (for gmail, this is your app password)
-- `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook url for alerts in application
-- `DOCKERHUB_TOKEN` - Dockerhub password
+- `KUBECONFIG` - Kubernetes cluster config for deploying to the cluster.
+- `TAILSCALE_OAUTH_CLIENT_ID` - Tailscale OAuth client ID used to connect the CI runner to the private cluster network.
+- `TAILSCALE_OAUTH_SECRET` - Tailscale OAuth secret paired with the client ID above.
+- `DOCKERHUB_USERNAME` - Docker Hub username for pushing images.
+- `DOCKERHUB_TOKEN` - Docker Hub access token.
+- `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
+- `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template <example@email.com>`).
+- `DEPLOYMENT_AUTH_EMAIL_HOST` - SMTP host (e.g. `smtp.gmail.com`).
+- `DEPLOYMENT_AUTH_EMAIL_PORT` - SMTP port (e.g. `465`).
+- `DEPLOYMENT_AUTH_EMAIL_USER` - SMTP username (for Gmail, this is your email address).
+- `DEPLOYMENT_AUTH_EMAIL_PASSWORD` - SMTP password (for Gmail, use an App Password).
+- `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook URL for in-application alerts.
 
 ## Deployments
 
-To configure deployment variables.
-Create a Github variable or secret and prefix it with `DEPLOYMENT_`.
+To pass additional environment variables to the running container, create a GitHub variable or secret and prefix the name with `DEPLOYMENT_`. The prefix is stripped before the value is injected into the container.
 
 ## Guides
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ bun dev
 
 #### Secrets
 
+The following secrets must be configured per repository.
+
+- `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
+- `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook URL for in-application alerts.
+
 The following secrets are configured at the organisation level and are inherited automatically — no action needed per repository.
 
 - `KUBECONFIG` - Kubernetes cluster config for deploying to the cluster.
@@ -46,11 +51,6 @@ The following secrets are configured at the organisation level and are inherited
 - `DEPLOYMENT_AUTH_EMAIL_PORT` - SMTP port (e.g. `465`).
 - `DEPLOYMENT_AUTH_EMAIL_USER` - SMTP username (for Gmail, this is your email address).
 - `DEPLOYMENT_AUTH_EMAIL_PASSWORD` - SMTP password (for Gmail, use an App Password).
-
-The following secrets must be configured per repository.
-
-- `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
-- `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook URL for in-application alerts.
 
 ## Deployments
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,22 @@ bun dev
 
 #### Secrets
 
+The following secrets are configured at the organisation level and are inherited automatically — no action needed per repository.
+
 - `KUBECONFIG` - Kubernetes cluster config for deploying to the cluster.
 - `TAILSCALE_OAUTH_CLIENT_ID` - Tailscale OAuth client ID used to connect the CI runner to the private cluster network.
 - `TAILSCALE_OAUTH_SECRET` - Tailscale OAuth secret paired with the client ID above.
 - `DOCKERHUB_USERNAME` - Docker Hub username for pushing images.
 - `DOCKERHUB_TOKEN` - Docker Hub access token.
-- `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
 - `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template <example@email.com>`).
 - `DEPLOYMENT_AUTH_EMAIL_HOST` - SMTP host (e.g. `smtp.gmail.com`).
 - `DEPLOYMENT_AUTH_EMAIL_PORT` - SMTP port (e.g. `465`).
 - `DEPLOYMENT_AUTH_EMAIL_USER` - SMTP username (for Gmail, this is your email address).
 - `DEPLOYMENT_AUTH_EMAIL_PASSWORD` - SMTP password (for Gmail, use an App Password).
+
+The following secrets must be configured per repository.
+
+- `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
 - `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook URL for in-application alerts.
 
 ## Deployments

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following secrets must be configured per repository.
 
 - `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
 - `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook URL for in-application alerts.
+- `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template`).
 
 The following secrets are configured at the organisation level and are inherited automatically — no action needed per repository.
 
@@ -46,7 +47,6 @@ The following secrets are configured at the organisation level and are inherited
 - `TAILSCALE_OAUTH_SECRET` - Tailscale OAuth secret paired with the client ID above.
 - `DOCKERHUB_USERNAME` - Docker Hub username for pushing images.
 - `DOCKERHUB_TOKEN` - Docker Hub access token.
-- `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template <example@email.com>`).
 - `DEPLOYMENT_AUTH_EMAIL_HOST` - SMTP host (e.g. `smtp.gmail.com`).
 - `DEPLOYMENT_AUTH_EMAIL_PORT` - SMTP port (e.g. `465`).
 - `DEPLOYMENT_AUTH_EMAIL_USER` - SMTP username (for Gmail, this is your email address).

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ bun dev
 - `APPLICATION_NAME` - Used as an identifier for multiple actions such as the Kubernetes deployment name and Terraform workspace.
 - `IMAGE_REPOSITORY` - Docker image repository to push the built image to (e.g. `dockerhub-username/app-name`).
 - `BASE_DOMAIN` - Domain where to host the application. Tags are deployed to this domain; pull requests to a subdomain using the commit SHA (e.g. `<sha>.yourdomain.com`).
+- `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template`).
 
 #### Secrets
 
 The following secrets must be configured per repository.
 
-- `DEPLOYMENT_AUTH_SECRET` - Auth.js secret for encrypting JWTs (generate with `bunx auth secret --raw`).
+- `DEPLOYMENT_AUTH_SECRET` - Better Auth secret for encrypting JWTs (generate with `bunx auth secret --raw`).
 - `DEPLOYMENT_DISCORD_WEBHOOK_URL` - Discord webhook URL for in-application alerts.
-- `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template`).
 
 The following secrets are configured at the organisation level and are inherited automatically — no action needed per repository.
 


### PR DESCRIPTION
## Summary

- Move `DOCKERHUB_USERNAME` from variables to secrets (it is declared as a `workflow_call` secret in `kubernetes-infrastructure/.github/workflows/deployments.yaml`, not a variable)
- Add three missing secrets required by the deployments workflow: `KUBECONFIG`, `TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_SECRET`
- Rename `AUTH_EMAIL_FROM_NAME` and all `AUTH_*` entries to their correct `DEPLOYMENT_`-prefixed names so they match how the deployment script strips the prefix before injecting them into the container
- Clarify what the `DEPLOYMENT_` prefix does in the Deployments section

## Test plan

- [ ] Verify all listed secrets/variables match what `deployments.yaml` declares under `workflow_call.secrets` and `env`
- [ ] Confirm `DEPLOYMENT_*` entries align with `.env.example` variable names (minus the prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)