### PR TITLE
fix(auth): compose email From as 'name <smtp-user>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ bun dev
 
 - `APPLICATION_NAME` - Used as an identifier for multiple actions such as the Kubernetes deployment name and Terraform workspace.
 - `BASE_DOMAIN` - Domain where to host the application. Tags are deployed to this domain; pull requests to a subdomain using the commit SHA (e.g. `<sha>.yourdomain.com`).
-- `DEPLOYMENT_AUTH_EMAIL_FROM` - Name and email address of the magic link sender (e.g. `Next Template`).
+- `DEPLOYMENT_AUTH_EMAIL_FROM` - Display name shown as the sender of the magic link emails (e.g. `Next Template`). The actual sender address is taken from `AUTH_EMAIL_USER`; the `From` header is composed as `AUTH_EMAIL_FROM <AUTH_EMAIL_USER>`.
 
 The following variables are configured at the organisation level and are inherited automatically — no action needed per repository.
 

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -29,7 +29,7 @@ export const auth = betterAuth({
       sendMagicLink: async ({ email, url }) => {
         const result = await transporter.sendMail({
           to: email,
-          from: env.AUTH_EMAIL_FROM,
+          from: `${env.AUTH_EMAIL_FROM} <${env.AUTH_EMAIL_USER}>`,
           subject: "Your sign-in link",
           text: `Click to sign in: ${url}\nThis link expires in 6 minutes.`,
           html: `<p>Click to sign in: <a href="${url}">${url}</a> this link expires in 6 minutes</p>`,


### PR DESCRIPTION
## Wat
De magic-link mails zetten `from: env.AUTH_EMAIL_FROM` rechtstreeks als afzender. De geconfigureerde waardes zijn echter weergavenamen (bv. `Next Template`, `Rutger's Todo App`) zonder e-mailadres — geen geldig From-adres.

## Verandering
`from` wordt nu samengesteld als:

```ts
from: `${env.AUTH_EMAIL_FROM} <${env.AUTH_EMAIL_USER}>`,
```

Dus: **weergavenaam** (`AUTH_EMAIL_FROM`) + het geauthenticeerde **SMTP-adres** (`AUTH_EMAIL_USER`). Resultaat bv. `Next Template <jouw@gmail.com>`.

## Effect
- Bestaande config blijft werken: `AUTH_EMAIL_FROM` is nu puur de weergavenaam (matcht ook de README-omschrijving).
- Geen nieuwe env-vars nodig; `AUTH_EMAIL_USER` bestond al.

🤖 Generated with [Claude Code](https://claude.com/claude-code)