### PR TITLE
feat: restart pod when configmap or secrets change

### DIFF
--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -62,6 +62,18 @@ resource "kubernetes_deployment" "app" {
         labels = {
           app = "${var.application_name}-deployment"
         }
+
+        # Force a rolling restart of the pod when secrets or config change.
+        # Updating only a Secret/ConfigMap value doesn't alter the pod spec, so
+        # the Deployment won't roll out and the pod keeps running with the old
+        # env. Hashing the values into a template annotation changes the pod
+        # template whenever they do, which forces a restart.
+        # (timestamp() can't be used here: it differs between plan and apply,
+        # which makes the kubernetes provider error with an inconsistent plan.)
+        annotations = {
+          "deployment/secrets-hash" = sha1(jsonencode(var.secrets))
+          "deployment/config-hash"  = sha1(jsonencode(var.config))
+        }
       }
 
       spec {


### PR DESCRIPTION
Ports the pod-restart-on-config-change pattern from `relay` into the template.

Updating only a Secret/ConfigMap value doesn't change the pod spec, so the Deployment never rolls out and the pod keeps running with stale env. This hashes `var.secrets` and `var.config` into pod template annotations (`deployment/secrets-hash`, `deployment/config-hash`), so any change forces a rolling restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)