### PR TITLE
fix: fail lint CI on warnings (--max-warnings 0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "bun --bun next dev --turbopack",
     "build": "bun --bun next build",
     "start": "bun --bun next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",


### PR DESCRIPTION
Makes the lint job strict so any ESLint warning fails CI. The template currently lints clean (0 warnings).

Verified locally: `bun run lint` passes with `--max-warnings 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)